### PR TITLE
Use maps for configuring repository rule based on cpu

### DIFF
--- a/graalvm/repository_rules/remote_graalvm_repository/defs.bzl
+++ b/graalvm/repository_rules/remote_graalvm_repository/defs.bzl
@@ -45,10 +45,12 @@ def _graalvm_distribution_is_executable_on_host(repository_ctx):
 
 def _download_and_install_graalvm_native_image_installable_jar(repository_ctx):
     JAR_PATH = "native_image_installable.jar"
+    result = repository_ctx.execute(["uname", "-m"])
+    cpu = result.stdout.strip()
     repository_ctx.download(
         output = JAR_PATH,
-        url = repository_ctx.attr.native_image_installable_jar_url,
-        sha256 = repository_ctx.attr.native_image_installable_jar_sha256,
+        url = repository_ctx.attr.native_image_installable_jar_url[cpu],
+        sha256 = repository_ctx.attr.native_image_installable_jar_sha256[cpu],
     )
     if _graalvm_distribution_is_executable_on_host(repository_ctx):
         exec_result = repository_ctx.execute(
@@ -79,19 +81,23 @@ def _remote_graalvm_repository_impl(repository_ctx):
 remote_graalvm_repository = repository_rule(
     implementation = _remote_graalvm_repository_impl,
     attrs = {
-        "url": attr.string(
+        "url": attr.string_dict(
+	    allow_empty = False,
             mandatory = True,
         ),
-        "sha256": attr.string(
+        "sha256": attr.string_dict(
+	    allow_empty = False,
             mandatory = True,
         ),
         "strip_prefix": attr.string(
             mandatory = True,
         ),
-        "native_image_installable_jar_url": attr.string(
+        "native_image_installable_jar_url": attr.string_dict(
+	    allow_empty = False,
             mandatory = True,
         ),
-        "native_image_installable_jar_sha256": attr.string(
+        "native_image_installable_jar_sha256": attr.string_dict(
+	    allow_empty = False,
             mandatory = True,
         ),
         # TODO(dwtj): Maybe figure out how to infer this attribute from context.
@@ -101,10 +107,6 @@ remote_graalvm_repository = repository_rule(
                 "linux",
                 "macos",
             ],
-        ),
-        "cpu": attr.string(
-            mandatory = True,
-            values = ["x64","aarch64"],
         ),
     }
 )

--- a/java/repository_rules/remote_openjdk_repository/defs.bzl
+++ b/java/repository_rules/remote_openjdk_repository/defs.bzl
@@ -17,7 +17,7 @@ def make_exec_compatible_with_str(repository_ctx):
     result = repository_ctx.execute(["uname", "-m"])
     cpu = result.stdout.strip()
     cpu_constraints_map = {
-        "amd64": "@platforms//cpu:x86_64",
+        "x86_64": "@platforms//cpu:x86_64",
         "aarch64": "@platforms//cpu:aarch64",
     }
 

--- a/java/repository_rules/remote_openjdk_repository/defs.bzl
+++ b/java/repository_rules/remote_openjdk_repository/defs.bzl
@@ -14,11 +14,14 @@ def make_exec_compatible_with_str(repository_ctx):
     if os_constraint == None:
         fail("Unexpected `os` attribute value: " + repository_ctx.attr.os)
 
+    result = repository_ctx.execute(["uname", "-m"])
+    cpu = result.stdout.strip()
     cpu_constraints_map = {
-        "x64": "@platforms//cpu:x86_64",
+        "amd64": "@platforms//cpu:x86_64",
         "aarch64": "@platforms//cpu:aarch64",
     }
-    cpu_constraint = cpu_constraints_map[repository_ctx.attr.cpu]
+
+    cpu_constraint = cpu_constraints_map[cpu]
     if cpu_constraint == None:
         fail("Unexpected `cpu` attribute value: " + repository_ctx.attr.cpu)
 
@@ -51,10 +54,12 @@ def _guess_jvm_shared_library_file(repository_ctx):
     return file
 
 def download_openjdk_dist_archive(repository_ctx):
+    result = repository_ctx.execute(["uname", "-m"])
+    cpu = result.stdout.strip()
     repository_ctx.download_and_extract(
         output = "jdk",
-        url = repository_ctx.attr.url,
-        sha256 = repository_ctx.attr.sha256,
+        url = repository_ctx.attr.url[cpu],
+        sha256 = repository_ctx.attr.sha256[cpu],
         stripPrefix = repository_ctx.attr.strip_prefix,
         allow_fail = False,
     )
@@ -182,10 +187,12 @@ def _remote_openjdk_repository_impl(repository_ctx):
 remote_openjdk_repository = repository_rule(
     implementation = _remote_openjdk_repository_impl,
     attrs = {
-        "url": attr.string(
+        "url": attr.string_dict(
+	    allow_empty = False,
             mandatory = True,
         ),
-        "sha256": attr.string(
+        "sha256": attr.string_dict(
+	    allow_empty = False,
             mandatory = True,
         ),
         "strip_prefix": attr.string(
@@ -197,13 +204,6 @@ remote_openjdk_repository = repository_rule(
             values = [
                 "linux",
                 "macos",
-            ],
-        ),
-        "cpu": attr.string(
-            mandatory = True,
-            values = [
-                "x64",
-                "aarch64",
             ],
         ),
     }


### PR DESCRIPTION
Allows artifacts from multiple architectures to be used in one repository rule